### PR TITLE
changes to force output to specific channels

### DIFF
--- a/smib.py
+++ b/smib.py
@@ -11,6 +11,7 @@ token = "xoxb-[PUT THE REAL TOKEN HERE]"
 bot_user = "U0XK12X63"
 
 programsdir = '/home/smib/smib-commands/'
+FORCE_CHANNEL = "FORCE_CHANNEL:"
 all_commands = {}
 all_commands_time = 0
 
@@ -92,38 +93,38 @@ if sc.rtm_connect():
                         if evt["channel"][:1] == "C":
                             try:
                                 p = subprocess.Popen([script, users[evt["user"]], chans[evt["channel"]], chans[evt["channel"]], argline], shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-                                lines = p.stdout.readlines()
-                                if len(lines) >= 1:
-                                    if "FORCE_CHANNEL:" in x[0]:
-                                        #remove the control line
-                                        lines = lines[1:]
-                                sc.api_call("chat.postMessage", as_user="false:", channel=evt["channel"], text=''.join(lines))
                             except:
                                 sc.api_call("chat.postMessage", as_user="false:", channel=evt["channel"], text=command+" is on fire!")
+                            lines = p.stdout.readlines()
+                            if len(lines) >= 1:
+                                if FORCE_CHANNEL in x[0]:
+                                    #remove the control line
+                                    lines = lines[1:]
+                            sc.api_call("chat.postMessage", as_user="false:", channel=evt["channel"], text=''.join(lines))
                         # Direct Messages
                         if evt["channel"][:1] == "D":
                             try:
                                 p = subprocess.Popen([script, users[evt["user"]], 'null', evt["channel"], argline], shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-                                lines = p.stdout.readlines()
-                                channel = evt["channel"]
-                                if len(lines) >= 1:
-                                    if "FORCE_CHANNEL:" in x[0]:
-                                        force = True
-                                        postchannel = x[0]
-                                        postchannel = postchannel[14:].lower()
-                                        if postchannel in chans.values():
-                                            for ch_id, chnl in chans.iteritems():    #dictionary.items() for Python 3.x
-                                                if chnl == postchannel:
-                                                    postchannel_id = ch_id
-                                        else:
-                                            for ch_id, chnl in chans.iteritems():    #dictionary.items() for Python 3.x
-                                                if chnl == 'general':
-                                                    postchannel_id = ch_id
-                                        #remove the control line
-                                        lines = lines[1:]
-                                sc.api_call("chat.postMessage", as_user="false:", channel=ch_id, text=''.join(lines))
                             except:
                                 sc.api_call("chat.postMessage", as_user="false:", channel=evt["channel"], text=command+" is on fire!")
+                            lines = p.stdout.readlines()
+                            channel = evt["channel"]
+                            if len(lines) >= 1:
+                                if FORCE_CHANNEL in x[0]:
+                                    force = True
+                                    postchannel = x[0]
+                                    postchannel = postchannel[len(FORCE_CHANNEL):].lower()
+                                    if postchannel in chans.values():
+                                        for ch_id, chnl in chans.iteritems():    #dictionary.items() for Python 3.x
+                                            if chnl == postchannel:
+                                                postchannel_id = ch_id
+                                    else:
+                                        for ch_id, chnl in chans.iteritems():    #dictionary.items() for Python 3.x
+                                            if chnl == 'general':
+                                                postchannel_id = ch_id
+                                    #remove the control line
+                                    lines = lines[1:]
+                                sc.api_call("chat.postMessage", as_user="false:", channel=ch_id, text=''.join(lines))
                     time.sleep(1)
                     continue
                 if evt["type"] == "user_change":

--- a/smib.py
+++ b/smib.py
@@ -7,7 +7,7 @@ import re
 import subprocess
 from slackclient import SlackClient
 
-token = "xoxb-316470992"
+token = "xoxb-[PUT THE REAL TOKEN HERE]"
 bot_user = "U0XK12X63"
 
 programsdir = '/home/smib/smib-commands/'
@@ -55,7 +55,7 @@ if sc.rtm_connect():
     
     chanslist = sc.api_call("channels.list")
     for channel in chanslist['channels']:
-        chans[channel["id"]] = channel["name"]
+        chans[channel["id"]] = channel["name"].lower()
     
     while True:
         try:
@@ -72,7 +72,7 @@ if sc.rtm_connect():
             if "type" in evt:
                 if evt["type"] == "message" and "text" in evt:
                     try:
-                        match = re.search(r"^\?(\w+) {0,1}(.*)", evt["text"], re.MULTILINE)
+                        match = re.search(r"^\?(\w+) (.*)", evt["text"], re.DOTALL)
                     except:
                         print evt
                         continue
@@ -92,18 +92,38 @@ if sc.rtm_connect():
                         if evt["channel"][:1] == "C":
                             try:
                                 p = subprocess.Popen([script, users[evt["user"]], chans[evt["channel"]], chans[evt["channel"]], argline], shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-                                sc.api_call("chat.postMessage", as_user="false:", channel=evt["channel"], text=''.join(p.stdout.readlines()))
+                                lines = p.stdout.readlines()
+                                if len(lines) >= 1:
+                                    if "FORCE_CHANNEL:" in x[0]:
+                                        #remove the control line
+                                        lines = lines[1:]
+                                sc.api_call("chat.postMessage", as_user="false:", channel=evt["channel"], text=''.join(lines))
                             except:
                                 sc.api_call("chat.postMessage", as_user="false:", channel=evt["channel"], text=command+" is on fire!")
-                            
                         # Direct Messages
                         if evt["channel"][:1] == "D":
                             try:
                                 p = subprocess.Popen([script, users[evt["user"]], 'null', evt["channel"], argline], shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-                                sc.api_call("chat.postMessage", as_user="false:", channel=evt["channel"], text=''.join(p.stdout.readlines()))
+                                lines = p.stdout.readlines()
+                                channel = evt["channel"]
+                                if len(lines) >= 1:
+                                    if "FORCE_CHANNEL:" in x[0]:
+                                        force = True
+                                        postchannel = x[0]
+                                        postchannel = postchannel[14:].lower()
+                                        if postchannel in chans.values():
+                                            for ch_id, chnl in chans.iteritems():    #dictionary.items() for Python 3.x
+                                                if chnl == postchannel:
+                                                    postchannel_id = ch_id
+                                        else:
+                                            for ch_id, chnl in chans.iteritems():    #dictionary.items() for Python 3.x
+                                                if chnl == 'general':
+                                                    postchannel_id = ch_id
+                                        #remove the control line
+                                        lines = lines[1:]
+                                sc.api_call("chat.postMessage", as_user="false:", channel=ch_id, text=''.join(lines))
                             except:
                                 sc.api_call("chat.postMessage", as_user="false:", channel=evt["channel"], text=command+" is on fire!")
-                            
                     time.sleep(1)
                     continue
                 if evt["type"] == "user_change":
@@ -115,8 +135,6 @@ if sc.rtm_connect():
                     chanslist = sc.api_call("channels.list")
                     for channel in chanslist['channels']:
                         chans[channel["id"]] = channel["name"]
-                
-                    
         time.sleep(0.1)
 else:
     print "Connection Failed, invalid token?"


### PR DESCRIPTION
To prevent DM'ing the bot to do things surreptitiously, privacy sensitive scripts  like webcam and enhance should only place results in the specified FORCE_CHANNEL location